### PR TITLE
Fix Control 6.1.3 to allow more restrictive perms

### DIFF
--- a/controls/6_1_system_file_permissions.rb
+++ b/controls/6_1_system_file_permissions.rb
@@ -83,8 +83,6 @@ control 'cis-dil-benchmark-6.1.3' do
   shadow_files.each do |f|
     describe file(f) do
       it { should exist }
-      it { should be_readable.by 'owner' }
-      it { should be_writable.by 'owner' }
       it { should_not be_executable.by 'owner' }
       it { should_not be_writable.by 'group' }
       it { should_not be_executable.by 'group' }


### PR DESCRIPTION
`CIS_Distribution_Independent_Linux_Benchmark_v2.0.0.pdf` states that /etc/shadow permissions should be 640 or MORE restrictive.

Prior to this edit, the control only allowed files with `0600` and `0640` permissions; however, this made permission sets like `0000` unacceptable. Removing the checks for `it { should be_readable.by 'owner' }` and `it { should be_writable.by 'owner' }` allows this bench mark to be more accurately implemented, in line with the recommendations of CIS DIL v2.0.0.