### PR TITLE
Expand Compatibility for Alternative Linux Distros

### DIFF
--- a/controls/1_7_warning_banners.rb
+++ b/controls/1_7_warning_banners.rb
@@ -28,6 +28,16 @@ control 'cis-dil-benchmark-1.7.1.1' do
   describe file('/etc/motd') do
     its(:content) { should_not match(/(\\v|\\r|\\m|\\s)/) }
   end
+
+  if file('/run/motd.dynamic').exist?
+    describe file('/run/motd.dynamic') do
+      its(:content) { should_not match(/(\\v|\\r|\\m|\\s)/) }
+    end
+  elsif directory('/etc/update-motd.d').directory?
+    describe command('/usr/bin/env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin run-parts --lsbsysinit /etc/update-motd.d') do
+      its(:stdout) { should_not match(/(\\v|\\r|\\m|\\s)/) }
+    end
+  end
 end
 
 control 'cis-dil-benchmark-1.7.1.2' do

--- a/controls/1_7_warning_banners.rb
+++ b/controls/1_7_warning_banners.rb
@@ -74,22 +74,41 @@ control 'cis-dil-benchmark-1.7.1.4' do
   tag cis: 'distribution-independent-linux:1.7.1.4'
   tag level: 1
 
-  describe file('/etc/motd') do
-    it { should exist }
-    it { should be_readable.by 'owner' }
-    it { should be_writable.by 'owner' }
-    it { should_not be_executable.by 'owner' }
-    it { should be_readable.by 'group' }
-    it { should_not be_writable.by 'group' }
-    it { should_not be_executable.by 'group' }
-    it { should be_readable.by 'other' }
-    it { should_not be_writable.by 'other' }
-    it { should_not be_executable.by 'other' }
-    its(:uid) { should cmp 0 }
-    its(:gid) { should cmp 0 }
-    its(:sticky) { should equal false }
-    its(:suid) { should equal false }
-    its(:sgid) { should equal false }
+  if file('/etc/motd').exist?
+    describe file('/etc/motd') do
+      it { should be_readable.by 'owner' }
+      it { should be_writable.by 'owner' }
+      it { should_not be_executable.by 'owner' }
+      it { should be_readable.by 'group' }
+      it { should_not be_writable.by 'group' }
+      it { should_not be_executable.by 'group' }
+      it { should be_readable.by 'other' }
+      it { should_not be_writable.by 'other' }
+      it { should_not be_executable.by 'other' }
+      its(:uid) { should cmp 0 }
+      its(:gid) { should cmp 0 }
+      its(:sticky) { should equal false }
+      its(:suid) { should equal false }
+      its(:sgid) { should equal false }
+    end
+  end
+
+  command('find -O3 /etc/update-motd.d -type f -perm /111').stdout.each_line do |fname|
+    describe file(fname.strip) do
+      it { should be_readable.by 'owner' }
+      it { should be_executable.by 'owner' }
+      it { should be_readable.by 'group' }
+      it { should_not be_writable.by 'group' }
+      it { should be_executable.by 'group' }
+      it { should be_readable.by 'other' }
+      it { should_not be_writable.by 'other' }
+      it { should be_executable.by 'other' }
+      its(:uid) { should cmp 0 }
+      its(:gid) { should cmp 0 }
+      its(:sticky) { should equal false }
+      its(:suid) { should equal false }
+      its(:sgid) { should equal false }
+    end
   end
 end
 

--- a/controls/5_4_user_accounts_and_environments.rb
+++ b/controls/5_4_user_accounts_and_environments.rb
@@ -163,7 +163,7 @@ control 'cis-dil-benchmark-5.4.4' do
 
   %w(bash.bashrc profile bashrc).each do |f|
     describe file("/etc/#{f}") do
-      its(:content) { should_not match(/^\s*umask [01234567](0[7654321]|[7654321][654321])\s*(?:#.*)?$/) }
+      its(:content) { should_not match(/^\s*umask [0124]?[01234567](0[7654321]|[7654321][654321])\s*(?:#.*)?$/) }
     end
   end
 
@@ -172,7 +172,7 @@ control 'cis-dil-benchmark-5.4.4' do
       next unless file("/etc/#{f}").file?
 
       describe file("/etc/#{f}") do
-        its(:content) { should match(/^\s*umask [01234567][2367]7\s*(?:#.*)?$/) }
+        its(:content) { should match(/^\s*umask 0?[01234567][2367]7\s*(?:#.*)?$/) }
       end
     end
   end

--- a/controls/5_4_user_accounts_and_environments.rb
+++ b/controls/5_4_user_accounts_and_environments.rb
@@ -161,14 +161,14 @@ control 'cis-dil-benchmark-5.4.4' do
   tag cis: 'distribution-independent-linux:5.4.4'
   tag level: 1
 
-  %w(bash.bashrc profile bashrc).each do |f|
+  %w(bash.bashrc bash.bashrc.local profile.local profile bashrc).each do |f|
     describe file("/etc/#{f}") do
       its(:content) { should_not match(/^\s*umask [0124]?[01234567](0[7654321]|[7654321][654321])\s*(?:#.*)?$/) }
     end
   end
 
   describe.one do
-    %w(bash.bashrc profile bashrc).each do |f|
+    %w(bash.bashrc bash.bashrc.local profile.local profile bashrc).each do |f|
       next unless file("/etc/#{f}").file?
 
       describe file("/etc/#{f}") do


### PR DESCRIPTION
This pull request expands existing CIS DIL Benchmark capabilities implement to the spirit of controls for many alternative Linux distributions. These include:

- Adding support for proper evaluation of Message of the Day (MOTD) content generated by  `pam_motd`, as occurs on Fedora, Ubuntu & Debian;
- Evaluation of MOTD file permissions for those Linux flavors using `pam_motd`;
- Expansion of Bash RC/Profile file checks to include `/etc/bash.bashrc.local` and  `/etc/profile.local`, which are used by SUSE and openSUSE; and
- Support for detecting/auditing four-digit `umask` values.